### PR TITLE
feat: make trustbridge plugin based on existing deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This repository is used to host the bits and pieces required to deploy trustbridge components into an AWS based environment using the [hamlet](https://hamlet.io) deployment framework.
 
 The process and tools used here are not specific to hamlet and are tools that we have used to make the deployment work.
+
+## Hamlet Plugin
+
+This repo also contains a hamlet plugin which can be used to deploy scalable production capable deployments of the trustbridge components.
+
+see hamlet/trustbrdige for the plugin details

--- a/hamlet/trustbridge/README.md
+++ b/hamlet/trustbridge/README.md
@@ -1,0 +1,15 @@
+# Hamlet Trustbridge Provider
+
+The hamlet Trustbridge provider is a set of established modules which implement different components in the trustbridge system. The module has been tested with AWS based deployments using the hamlet deployment framework.
+
+Each application component is broken up into its own module allowing for users to pick and choose the implementations appropriate to them
+
+## Modules
+
+- channel_api - is a serverless deployment of the [API based Channel](https://github.com/trustbridge/api-channel) and consists of the components for a single jurisdiction deployment
+- channel_shareddb - is a serverless deployment of the [Shared DB Testing Channel](shared-db-channel) and includes all the components to deploy a single jurisdction or instance. To deploy multiple jurisdictions invoke this module multiple times in the same solution with the `instance` id value unique for each instance
+- intergov - is a serverless deployment of the [intergov document store](https://github.com/trustbridge/intergov) and contains all of the components required for single jurisdiction deployment
+
+## Extensions
+
+The core components of each module have a corresponding extension which handles the configuration required for those components

--- a/hamlet/trustbridge/extensions/channel_api/extension.ftl
+++ b/hamlet/trustbridge/extensions/channel_api/extension.ftl
@@ -1,0 +1,122 @@
+[#ftl]
+
+[@addExtension
+    id="channel_api"
+    aliases=[
+        "_channel_api"
+    ]
+    description=[
+        "Provides standard configuration for the API Channel components"
+    ]
+    supportedTypes=[
+        ECS_SERVICE_COMPONENT_TYPE,
+        ECS_TASK_COMPONENT_TYPE,
+        LAMBDA_COMPONENT_TYPE,
+        LAMBDA_FUNCTION_COMPONENT_TYPE
+    ]
+/]
+
+
+[#macro shared_extension_channel_api_deployment_setup occurrence ]
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+    [@DefaultBaselineVariables enabled=false /]
+
+    [@Settings
+        [
+            "TESTING",
+            "KMS_PREFIX",
+            "SENTRY_DSN",
+            "FOREIGN_ENDPOINT_URL"
+        ]
+    /]
+
+    [#assign awsRegion = (_context.DefaultEnvironment["AWS_REGION"])!"ap-southeast-2" ]
+    [@Settings
+        {
+            "SENTRY_ENVIRONMENT"            : _context.DefaultEnvironment["ENVIRONMENT"]!"",
+            "SENTRY_RELEASE"                : _context.DefaultEnvironment["APP_REFERENCE"]!(_context.DefaultEnvironment["BUILD_REFERENCE"]!""),
+            "PREFERRED_URL_SCHEME"          : "https",
+            "IGL_DEFAULT_S3_USE_SSL"        : "true",
+            "IGL_DEFAULT_S3_REGION"         : awsRegion,
+            "IGL_DEFAULT_S3_HOST"           : formatDomainName("s3", awsRegion, "amazonaws.com"),
+            "IGL_DEFAULT_S3_PORT"           : "443",
+            "IGL_DEFAULT_S3_ACCESS_KEY"     : "",
+            "IGL_DEFAULT_S3_SECRET_KEY"     : "",
+            "IGL_DEFAULT_SQS_USE_SSL"       : "true",
+            "IGL_DEFAULT_SQS_PORT"          : "443",
+            "IGL_DEFAULT_SQS_SECRET_KEY"    : "",
+            "IGL_DEFAULT_SQS_ACCESS_KEY"    : "",
+            "IGL_DEFAULT_SQS_REGION"        : awsRegion,
+            "IGL_DEFAULT_SQS_HOST"          : formatDomainName("sqs", awsRegion, "amazonaws.com")
+        }
+    /]
+
+    [#-- Environment variables --]
+    [#list _context.DefaultEnvironment as env,value ]
+        [#if env?starts_with("BKT") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("BKT_"))?remove_ending("_NAME") ]
+
+            [@Settings
+                {
+                    envvar + "_BUCKET"      : value
+                }
+            /]
+        [/#if]
+
+        [#if env?starts_with("QUE") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("QUE_"))?remove_ending("_NAME") ]
+            [@Settings
+                {
+                    envvar + "_QNAME"       : value
+                }
+            /]
+        [/#if]
+    [/#list]
+
+    [#list _context.Links as id,link ]
+        [#if link.Core.Type == S3_COMPONENT_TYPE ]
+            [@Policy
+                [
+                    getS3BucketStatement(
+                        [
+                            "s3:ListBucket",
+                            "s3:GetBucketLocation"
+                        ],
+                        link.State.Resources["bucket"].Id
+                    )
+                ]
+
+            /]
+        [/#if]
+    [/#list]
+
+    [@AltSettings
+        {
+            "SENTRY_ENVIRONMENT" : "ENVIRONMENT",
+            "SENTRY_RELEASE" : "BUILD_REFERENCE",
+            "SERVICE_URL" : "ENDPOINT_URL",
+            "JURISDICTION" : "IGL_JURISDICTION",
+            "SERVICE_NAME" : "API_FQDN",
+            "SERVICE_URL"  : "API_URL"
+        }
+    /]
+
+    [#switch (_context.Mode)!"" ]
+        [#case "DELV"]
+            [@Command [ "python", "manage.py", "run_callback_delivery" ] /]
+            [#break]
+
+        [#case "SPRD"]
+            [@Command [ "python", "manage.py", "run_callback_spreader" ] /]
+            [#break]
+
+        [#case "SENDPROC"]
+            [@Command [ "python", "manage.py", "run_send_message_processor" ] /]
+            [#break]
+    [/#switch]
+
+[#macro]

--- a/hamlet/trustbridge/extensions/channel_shareddb/extension.ftl
+++ b/hamlet/trustbridge/extensions/channel_shareddb/extension.ftl
@@ -1,0 +1,120 @@
+[#ftl]
+
+[@addExtension
+    id="channel_shareddb"
+    aliases=[
+        "_channel_sharedb"
+    ]
+    description=[
+        "Provides standard configuration for the Shared DB components"
+    ]
+    supportedTypes=[
+        ECS_SERVICE_COMPONENT_TYPE,
+        ECS_TASK_COMPONENT_TYPE,
+        LAMBDA_COMPONENT_TYPE,
+        LAMBDA_FUNCTION_COMPONENT_TYPE
+    ]
+/]
+
+
+[#macro shared_extension_channel_shareddb_deployment_setup occurrence ]
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+    [@DefaultBaselineVariables enabled=false /]
+
+    [@Settings
+        [
+            "KMS_PREFIX",
+            "SENTRY_DSN",
+            "JURISDICTION"
+        ]
+    /]
+
+    [#assign awsRegion = (_context.DefaultEnvironment["AWS_REGION"])!"ap-southeast-2" ]
+    [@Settings
+        {
+            "SENTRY_ENVIRONMENT"            : _context.DefaultEnvironment["ENVIRONMENT"]!"",
+            "SENTRY_RELEASE"                : _context.DefaultEnvironment["APP_REFERENCE"]!(_context.DefaultEnvironment["BUILD_REFERENCE"]!""),
+            "SERVER_NAME"                   : _context.DefaultEnvironment["API_FQDN"]!"",
+            "SERVICE_URL"                   : _context.DefaultEnvironment["API_URL"]!"",
+            "PREFERRED_URL_SCHEME"          : "https",
+            "IGL_DEFAULT_S3_USE_SSL"        : "true",
+            "IGL_DEFAULT_S3_REGION"         : awsRegion,
+            "IGL_DEFAULT_S3_HOST"           : formatDomainName("s3", awsRegion, "amazonaws.com"),
+            "IGL_DEFAULT_S3_PORT"           : "443",
+            "IGL_DEFAULT_S3_ACCESS_KEY"     : "",
+            "IGL_DEFAULT_S3_SECRET_KEY"     : "",
+            "IGL_DEFAULT_SQS_USE_SSL"       : "true",
+            "IGL_DEFAULT_SQS_PORT"          : "443",
+            "IGL_DEFAULT_SQS_SECRET_KEY"    : "",
+            "IGL_DEFAULT_SQS_ACCESS_KEY"    : "",
+            "IGL_DEFAULT_SQS_REGION"        : awsRegion,
+            "IGL_DEFAULT_SQS_HOST"          : formatDomainName("sqs", awsRegion, "amazonaws.com")
+        }
+    /]
+
+    [#-- Environment variables --]
+    [#list _context.DefaultEnvironment as env,value ]
+        [#if env?starts_with("BKT") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("BKT_"))?remove_ending("_NAME") ]
+
+            [@Settings
+                {
+                    envvar + "_BUCKET"      : value
+                }
+            /]
+        [/#if]
+
+        [#if env?starts_with("QUE") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("QUE_"))?remove_ending("_NAME") ]
+            [@Settings
+                {
+                    envvar + "_QNAME"       : value
+                }
+            /]
+        [/#if]
+    [/#list]
+
+    [#list _context.Links as id,link ]
+        [#if link.Core.Type == S3_COMPONENT_TYPE ]
+            [@Policy
+                [
+                    getS3BucketStatement(
+                        [
+                            "s3:ListBucket",
+                            "s3:GetBucketLocation"
+                        ],
+                        link.State.Resources["bucket"].Id
+                    )
+                ]
+
+            /]
+        [/#if]
+    [/#list]
+
+    [@AltSettings
+        {
+            "DATABASE_URI" : "DATABASE_URL",
+            "SENTRY_ENVIRONMENT" : "ENVIRONMENT",
+            "SENTRY_RELEASE" : "BUILD_REFERENCE"
+        }
+    /]
+
+    [#switch (_context.Mode)!"" ]
+        [#case "DELV"]
+            [@Command [ "python", "manage_production.py", "run_callback_delivery" ] /]
+            [#break]
+
+        [#case "SPRD"]
+            [@Command [ "python", "manage_production.py", "run_callback_spreader" ] /]
+            [#break]
+
+        [#case "OBSV"]
+            [@Command [ "python", "manage_production.py", "run_message_observer" ] /]
+            [#break]
+    [/#switch]
+
+[#macro]

--- a/hamlet/trustbridge/extensions/intergov_services/extension.ftl
+++ b/hamlet/trustbridge/extensions/intergov_services/extension.ftl
@@ -1,0 +1,213 @@
+[#ftl]
+
+[@addExtension
+    id="intergov_services"
+    aliases=[
+        "_intergov_srv"
+    ]
+    description=[
+        "Provides the configuration shared between the api and processor components in the intergov module"
+    ]
+    supportedTypes=[
+        ECS_SERVICE_COMPONENT_TYPE,
+        ECS_TASK_COMPONENT_TYPE,
+        LAMBDA_COMPONENT_TYPE,
+        LAMBDA_FUNCTION_COMPONENT_TYPE
+    ]
+/]
+
+
+[#macro shared_extension_intergov_services_deployment_setup occurrence ]
+
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+    [@DefaultBaselineVariables enabled=false /]
+
+
+    [#assign awsRegion = (_context.DefaultEnvironment["AWS_REGION"])!"ap-southeast-2" ]
+
+    [@Settings
+        [
+            "KMS_PREFIX",
+            "SENTRY_DSN",
+            "IGL_JURISDICTION"
+        ]
+    /]
+
+    [@AltSettings
+        {
+            "IGL_APP_JURISDICTION" : "IGL_JURISDICTION"
+        }
+    /]
+
+    [#-- Custom Cloudwatch Metrics --]
+    [#assign iglMetricsNamespace = "IGL" ]
+    [@Settings
+        {
+            "CLOUDWATCH_NAMESPACE" : iglMetricsNamespace,
+            "SEND_CLOUDWATCH_METRICS" : "true"
+        }
+    /]
+    [@Policy
+        [
+            getPolicyStatement(
+                [ "cloudwatch:PutMetricData" ],
+                "*",
+                "",
+                {
+                    "StringEquals" : {
+                        "cloudwatch:namespace" : iglMetricsNamespace
+                    }
+                }
+            )
+        ]
+    /]
+
+    [@Settings
+        {
+            "SENTRY_ENVIRONMENT"            : _context.DefaultEnvironment["ENVIRONMENT"]!"",
+            "SENTRY_RELEASE"                : _context.DefaultEnvironment["APP_REFERENCE"]!(_context.DefaultEnvironment["BUILD_REFERENCE"]!""),
+            "IGL_MCHR_ROUTING_TABLE"        : _context.DefaultEnvironment["IGL_MCHR_ROUTING_TABLE"]!"",
+            "IGL_JURISDICTION_OAUTH_CLIENT_ID"   : _context.DefaultEnvironment["IGL_JURISDICTION_OAUTH_CLIENT_ID"]!"",
+            "IGL_JURISDICTION_OAUTH_CLIENT_SECRET"   : _context.DefaultEnvironment["IGL_JURISDICTION_OAUTH_CLIENT_SECRET"]!"",
+            "IGL_JURISDICTION_OAUTH_SCOPES"      : _context.DefaultEnvironment["IGL_JURISDICTION_OAUTH_SCOPES"]!"",
+            "IGL_JURISDICTION_OAUTH_WELLKNOWN_URL" : _context.DefaultEnvironment["IGL_JURISDICTION_OAUTH_WELLKNOWN_URL"]!"",
+            "IGL_JURISDICTION_DOCUMENT_REPORTS"  : _context.DefaultEnvironment["IGL_JURISDICTION_DOCUMENT_REPORTS"]!"",
+            "IGL_DEFAULT_S3_USE_SSL"        : "true",
+            "IGL_DEFAULT_S3_REGION"         : awsRegion,
+            "IGL_DEFAULT_S3_HOST"           : formatDomainName("s3", awsRegion, "amazonaws.com"),
+            "IGL_DEFAULT_S3_PORT"           : "443",
+            "IGL_DEFAULT_S3_ACCESS_KEY"     : "",
+            "IGL_DEFAULT_S3_SECRET_KEY"     : "",
+            "IGL_DEFAULT_SQS_USE_SSL"       : "true",
+            "IGL_DEFAULT_SQS_PORT"          : "443",
+            "IGL_DEFAULT_SQS_SECRET_KEY"    : "",
+            "IGL_DEFAULT_SQS_ACCESS_KEY"    : "",
+            "IGL_DEFAULT_SQS_REGION"        : awsRegion,
+            "IGL_DEFAULT_SQS_HOST"          : formatDomainName("sqs", awsRegion, "amazonaws.com")
+        }
+    /]
+
+    [#-- Environment variables --]
+    [#list _context.DefaultEnvironment as env,value ]
+        [#if env?starts_with("BKT") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("BKT_"))?remove_ending("_NAME") ]
+
+            [@Settings
+                {
+                    envvar + "_BUCKET"      : value
+                }
+            /]
+        [/#if]
+
+        [#if env?starts_with("QUE") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("QUE_"))?remove_ending("_NAME") ]
+            [@Settings
+                {
+                    envvar + "_QNAME"       : value
+                }
+            /]
+        [/#if]
+
+        [#if env?starts_with("DB") && env?ends_with("NAME") ]
+
+            [#assign envvar = (env?remove_beginning("DB_"))?remove_ending("_NAME") ]
+            [#assign host = (_context.DefaultEnvironment[ (env?remove_ending("_NAME")?ensure_ends_with("_FQDN"))])!"" ]
+            [#assign user = (_context.DefaultEnvironment[ (env?remove_ending("_NAME")?ensure_ends_with("_USERNAME"))])!"" ]
+            [#assign password = (_context.DefaultEnvironment[ (env?remove_ending("_NAME")?ensure_ends_with("_PASSWORD"))])!""]
+            [@Settings
+                {
+                    envvar + "_HOST"            : host,
+                    envvar + "_USER"            : user,
+                    envvar + "_PASSWORD"        : password,
+                    envvar + "_DBNAME"          : value
+                }
+            /]
+        [/#if]
+
+        [#if env == "IGL_PROC_BCH_MESSAGE_RX_API_URL" ]
+            [@Settings
+                [
+                    "IGL_PROC_BCH_MESSAGE_RX_API_URL"
+                ]
+            /]
+        [/#if]
+
+        [#if env == "IGL_PROC_BCH_MESSAGE_API_URL" ]
+            [@Settings
+                {
+                    "IGL_PROC_BCH_MESSAGE_API_ENDPOINT" : formatRelativePath( value, "message", "{sender}:{sender_ref}" )
+                }
+            /]
+        [/#if]
+    [/#list]
+
+    [#list _context.Links as id,link ]
+        [#if link.Core.Type == S3_COMPONENT_TYPE ]
+            [@Policy
+                [
+                    getS3BucketStatement(
+                        [
+                            "s3:ListBucket",
+                            "s3:GetBucketLocation"
+                        ],
+                        link.State.Resources["bucket"].Id
+                    )
+                ]
+
+            /]
+        [/#if]
+    [/#list]
+
+    [#-- docker command overrides --]
+    [#assign pythonPath = {
+        "PYTHONPATH" : "/src/"
+    }]
+
+    [#switch (_context.Mode)!"" ]
+        [#case "MSG"]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/message_processor/__init__.py" ] /]
+            [#break]
+        [#case "CALLBDEL"]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/callback_deliver/__init__.py" ] /]
+            [#break]
+        [#case "CALLBSPD"]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/callbacks_spreader/__init__.py" ] /]
+            [#break]
+        [#case "REJSTAT" ]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/rejected_status_updater/__init__.py" ] /]
+            [#break]
+        [#case "CHANNELROUTER" ]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/multichannel_router/__init__.py" ] /]
+            [#break]
+        [#case "DOCSPIDER"]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/obj_spider/__init__.py" ] /]
+            [#break]
+        [#case "CHANNELPOLLER"]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/channel_poller/__init__.py" ] /]
+            [#break]
+        [#case "MSGUPDATER" ]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/message_updater/__init__.py" ] /]
+            [#break]
+        [#case "SUBHANDLER" ]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/subscription_handler/__init__.py" ] /]
+            [#break]
+        [#case "CHNMSGRET"]
+            [@Settings pythonPath /]
+            [@Command [ "python", "intergov/processors/channel_message_retriever/__init__.py" ] /]
+            [#break]
+    [/#switch]
+
+[/#macro]

--- a/hamlet/trustbridge/modules/channel_api/module.ftl
+++ b/hamlet/trustbridge/modules/channel_api/module.ftl
@@ -1,0 +1,413 @@
+[#ftl]
+
+[@addModule
+    name="channel_api"
+    description="A API based document sharing implementation"
+    provider=TRUSTBRIDGE_PROVIDER
+    properties=[
+        {
+            "Names" : "foreignEndpointUrl",
+            "Description" : "The Url of the foreign API to send documents to",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "sentryDSN",
+            "Description" : "The Sentry DSN for exception reporting",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "kmsPrefix",
+            "Description" : "The Sentry DSN for exception reporting",
+            "Type" : STRING_TYPE,
+            "Default" : "kms+base64"
+        }
+    ]
+/]
+
+
+[#macro trustbridge_module_channel_api foreignEndpointUrl]
+    [@loadModule
+
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : formatName( namespace, "apichannel"),
+                "Settings" : {
+                    "FOREIGN_ENDPOINT_URL" : foreignEndpointUrl,
+                    "Testing" : "False,
+                    "SENTRY_DSN" : sentryDSN,
+                    "KMS_PREFIX" : kmsPrefix
+                }
+            },
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : formatName( namespace, "apichannel-api"),
+                "Settings" : {
+                    "apigw" : {
+                        "Internal" : true,
+                        "Value" : {
+                            "Type" : "lambda",
+                            "Proxy" : false,
+                            "BinaryTypes" : ["*/*"],
+                            "ContentHandling" : "CONVERT_TO_TEXT",
+                            "Variable" : "LAMBDA_API_LAMBDA"
+                        }
+                    }
+                }
+            }
+        ]
+
+        blueprint={
+            "Tiers" : {
+                "api" : {
+                    "Components" : {
+                        "apichannel" : {
+                            "Title" : "API Channel",
+                            "APIGateway" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["apichannel-api"]
+                                            }
+                                        }
+
+                                    }
+                                },
+                                "Certificate" : {
+                                    "IncludeInDomain" : {
+                                        "Environment" : true
+                                    },
+                                    "IncludeInHost" : {
+                                        "Product" : false,
+                                        "Environment" : false,
+                                        "Tier" : false,
+                                        "Component" : true,
+                                        "Instance" : true,
+                                        "Version" : false,
+                                        "Host" : false
+                                    }
+                                },
+                                "EndpointType" : "REGIONAL",
+                                "Mapping" : {
+                                    "IncludeStage" : true
+                                },
+                                "WAF" : {
+                                    "IPAddressGroups" : ["_global"]
+                                },
+                                "Profiles" : {
+                                    "Deployment" : [ "APIChannel" ]
+                                },
+                                "Links" : {
+                                    "lambda" : {
+                                        "Tier" : "api",
+                                        "Component" : "apichannel-lambda",
+                                        "Function" : "api"
+                                    }
+                                }
+                            }
+                        },
+                        "apichannel-lambda" : {
+                            "Title" : "Lambda to support Ethereum Channel API",
+                            "Lambda" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["apichannel-api-imp"]
+                                            }
+                                        }
+                                    }
+                                },
+                                "RunTime" : "python3.6",
+                                "MemorySize" : 256,
+                                "Timeout" : 30,
+                                "Profiles" : {
+                                    "Deployment" : [ "APIChannel" ]
+                                },
+                                "Functions" : {
+                                    "api" : {
+                                        "Handler" : "wsgi_handler.handler",
+                                        "PredefineLogGroup" : true,
+                                        "Extensions" : [ "_channel_api" ],
+                                        "Links"  : {
+                                            "API" : {
+                                                "Tier" : "api",
+                                                "Component" : "apichannel",
+                                                "Direction" : "inbound"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "app" : {
+                    "Components" : {
+                        "app-ecs" : {
+                            "ecs" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : [ "app-ecs" ]
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Processor" : "default"
+                                },
+                                "Services" : {
+                                    "apichannel-processor" : {
+                                        "Instances" : {
+                                            "delv" : {
+                                                "Name" : "delivery",
+                                                "DeploymentUnits" : [ "apichannel-delivery" ],
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "apichannel-sqs",
+                                                                "Instance" : "delvoutbox",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Profiles" : {
+                                                    "Deployment" : [ "APIChannel", "QueueWorker"]
+                                                },
+                                                "Containers" : {
+                                                    "_apichannelprocessor-delv" : {
+                                                        "Extensions" : [ "_channel_api" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512
+                                                    }
+                                                }
+                                            },
+                                            "sendproc" : {
+                                                "Name" : "sendprocessor",
+                                                "DeploymentUnits" : [ "apichannel-sendproc" ],
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "apichannel-sqs",
+                                                                "Instance" : "channel",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Profiles" : {
+                                                    "Deployment" : [ "APIChannel", "QueueWorker"]
+                                                },
+                                                "Containers" : {
+                                                    "_apichannelprocessor-sendproc" : {
+                                                        "Extensions" : [ "_channel_api" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512
+                                                    }
+                                                }
+                                            },
+                                            "sprd" : {
+                                                "Name" : "spreader",
+                                                "DeploymentUnits" : [ "apichannel-spreader" ],
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "apichannel-sqs",
+                                                                "Instance" : "notifications",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Profiles" : {
+                                                    "Deployment" : [ "APIChannel", "QueueWorker"]
+                                                },
+                                                "Containers" : {
+                                                    "_apichannelprocessor-sprd" : {
+                                                        "Extensions" : [ "_channel_api" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512
+                                                    }
+                                                }
+
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "msg" : {
+                    "Components" : {
+                        "apichannel-s3" : {
+                            "s3" : {
+                                "DeploymentUnits" : [ "apichannel-s3"],
+                                "Instances" : {
+                                    "sub" : {},
+                                    "channel": {}
+                                }
+                            }
+                        },
+                        "apichannel-sqs" : {
+                            "sqs" : {
+                                "DeploymentUnits" : [ "apichannel-sqs" ],
+                                "Instances" : {
+                                    "notifications" : { },
+                                    "delvoutbox" : {},
+                                    "channel" : {}
+                                },
+                                "DeadLetterQueue" : {
+                                    "MaxReceives" : 20
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "DeploymentProfiles" : {
+                "QueueWorker" : {
+                    "Modes" : {
+                        "*" : {
+                            "service" : {
+                                "Engine" : "fargate",
+                                "NetworkMode" : "awsvpc",
+                                "Profiles" : {
+                                    "Processor" : "QueueWorker"
+                                },
+                                "ScalingPolicies" : {
+                                    "numberOfMessages" : {
+                                        "Type" : "Stepped",
+                                        "TrackingResource" : {
+                                            "Link" : {
+                                                "Tier" : "msg",
+                                                "Component" : "_REPLACEWITHLINK_",
+                                                "Instance" : "_REPLACEWITHLINK_",
+                                                "Version" : "_REPLACEWITHLINK_"
+                                            },
+                                            "MetricTrigger" : {
+                                                "Namespace": "AWS/SQS",
+                                                "Name" : "NumberOfMessages",
+                                                "Metric" : "ApproximateNumberOfMessagesVisible",
+                                                "Threshold" : 0,
+                                                "Severity" : "info",
+                                                "Statistic" : "Sum",
+                                                "Operator" : "GreaterThanThreshold",
+                                                "Periods" : 1,
+                                                "Time" : 60,
+                                                "Resource" : {
+                                                    "Id" : "queue"
+                                                }
+                                            }
+                                        },
+                                        "Stepped" : {
+                                            "CapacityAdjustment" : "Exact",
+                                            "Adjustments": {
+                                                "out1" : {
+                                                    "LowerBound": 1,
+                                                    "UpperBound": 1000,
+                                                    "AdjustmentValue": 1
+                                                },
+                                                "out2" : {
+                                                    "LowerBound": 1000,
+                                                    "AdjustmentValue": 2
+                                                },
+                                                "in1" : {
+                                                    "UpperBound": 1,
+                                                    "AdjustmentValue": 0
+                                                }
+                                            }
+                                        },
+                                        "Cooldown" : {
+                                            "ScaleOut" : 10,
+                                            "ScaleIn" : 300
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "APIChannel" : {
+                    "Modes" : {
+                        "*" : {
+                            "*" : {
+                                "SettingNamespaces" : {
+                                    "apichannel" : {
+                                        "Name" : "apichannel",
+                                        "Match" : "partial",
+                                        "IncludeInNamespace" : {
+                                            "Tier" : false,
+                                            "Component" : false,
+                                            "Type" : false,
+                                            "SubComponent" : false,
+                                            "Instance" : false,
+                                            "Version" : false,
+                                            "Name" : true
+                                        }
+                                    }
+                                },
+                                "Links"  : {
+                                    "API" : {
+                                        "Tier" : "api",
+                                        "Component" : "apichannel",
+                                        "Instance" : "",
+                                        "Version" : "v1"
+                                    },
+                                    "QUE_IGL_DELIVERY_OUTBOX_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "apichannel-sqs",
+                                        "Instance" : "delvoutbox",
+                                        "Version" : "",
+                                        "Role" : "all"
+                                    },
+                                    "BKT_IGL_SUBSCRIPTIONS_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "apichannel-s3",
+                                        "Instance" : "sub",
+                                        "Version" : "",
+                                        "Role" : "all"
+                                    },
+                                    "QUE_IGL_NOTIFICATIONS_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "apichannel-sqs",
+                                        "Instance" : "notifications",
+                                        "Version" : "",
+                                        "Role" : "all"
+                                    },
+                                    "BKT_IGL_CHANNEL_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "apichannel-s3",
+                                        "Instance" : "channel",
+                                        "Version" : "",
+                                        "Role" : "all"
+                                    },
+                                    "QUE_IGL_CHANNEL_QUEUE_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "apichannel-sqs",
+                                        "Instance" : "channel",
+                                        "Version" : "",
+                                        "Role" : "all"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+[/#macro]

--- a/hamlet/trustbridge/modules/channel_shareddb/module.ftl
+++ b/hamlet/trustbridge/modules/channel_shareddb/module.ftl
@@ -1,0 +1,581 @@
+[#ftl]
+
+[@addModule
+    name="channel_shareddb"
+    description="A shared db channel for document sharing - generally used for testing"
+    provider=TRUSTBRIDGE_PROVIDER
+    properties=[
+        {
+            "Names" : "instance",
+            "Description" : The id of the api instance",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "jurisdiction",
+            "Description" : The code of the local jurisdiction",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "sentryDSN",
+            "Description" : "The Sentry DSN for exception reporting",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "kmsPrefix",
+            "Description" : "The Sentry DSN for exception reporting",
+            "Type" : STRING_TYPE,
+            "Default" : "kms+base64"
+        }
+    ]
+/]
+
+
+[#macro trustbridge_module_channel_api
+        instance
+        sentryDSN
+        kmsPrefix
+    ]
+
+    [@loadModule
+
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : formatName( namespace, "sharedchannel", instance),
+                "Settings" : {
+                    "SENTRY_DSN" : sentryDSN,
+                    "KMS_PREFIX" : kmsPrefix,
+                    "JURISDICTION" : jurisdiction
+                }
+            },
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : formatName( namespace, "sharedchannel-api", instance),
+                "Settings" : {
+                    "apigw" : {
+                        "Internal" : true,
+                        "Value" : {
+                            "Type" : "lambda",
+                            "Proxy" : false,
+                            "BinaryTypes" : ["*/*"],
+                            "ContentHandling" : "CONVERT_TO_TEXT",
+                            "Variable" : "LAMBDA_API_LAMBDA",
+                            "SecuritySchemes" : {
+                                "oidc" : {
+                                    "Type" : "openIdConnect",
+                                    "Authorizer" : {
+                                        "Type" : "cognito_user_pools",
+                                        "Default" : true
+                                    }
+                                }
+                            },
+                            "OptionsSecurity" : "disabled",
+                            "Security" : {
+                                "auth" : {
+                                    "Enabled" : true,
+                                    "Scopes" : [ "https://sharedchannel" + instance + "/full" ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+
+        blueprint={
+            "Tiers" : {
+                "api" : {
+                    "Components" : {
+                        "sharedchannel" : {
+                            "Title" : "Shared Channel API",
+                            "APIGateway" : {
+                                "Instances" : {
+                                    instance : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : [ "sharedchannel-api-" + instance ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Certificate" : {
+                                    "IncludeInDomain" : {
+                                        "Environment" : true
+                                    },
+                                    "IncludeInHost" : {
+                                        "Product" : false,
+                                        "Environment" : false,
+                                        "Tier" : false,
+                                        "Component" : true,
+                                        "Instance" : true,
+                                        "Version" : false,
+                                        "Host" : false
+                                    }
+                                },
+                                "EndpointType" : "REGIONAL",
+                                "Mapping" : {
+                                    "IncludeStage" : true
+                                },
+                                "WAF" : {
+                                    "IPAddressGroups" : ["_global"]
+                                },
+                                "Links" : {
+                                    "lambda" : {
+                                        "Tier" : "api",
+                                        "Component" : "sharedchannel-lambda",
+                                        "Function" : "api"
+                                    },
+                                    "auth" : {
+                                        "Tier" : "dir",
+                                        "Component" : "auth-userpool",
+                                        "Instance" : "",
+                                        "Version" : ""
+                                    }
+                                }
+                            }
+                        },
+                        "sharedchannel-lambda" : {
+                            "Title" : "Lambda to support API",
+                            "Lambda" : {
+                                "Instances" : {
+                                    instance : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : [ "sharedchannel-api-imp-" + instance]
+                                            }
+                                        },
+                                        "Profiles" : {
+                                            "Deployment" : [ "C1Endpoint"]
+                                        }
+                                    }
+                                },
+                                "RunTime" : "python3.6",
+                                "MemorySize" : 256,
+                                "Timeout" : 30,
+                                "Profiles" : {
+                                    "Deployment" : [ "SharedChannel"]
+                                },
+                                "Functions" : {
+                                    "api" : {
+                                        "Handler" : "wsgi_handler.handler",
+                                        "PredefineLogGroup" : true,
+                                        "Extensions" : [ "channel_shareddb" ],
+                                        "Links"  : {
+                                            "api" : {
+                                                "Tier" : "api",
+                                                "Component" : "sharedchannel",
+                                                "Direction" : "inbound"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sharedutils-lambda" : {
+                            "Title" : "Utility functions for shared channel deploy",
+                            "Lambda" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["sharedchannel-utilities"]
+                                    }
+                                },
+                                "RunTime" : "python3.6",
+                                "MemorySize" : 256,
+                                "Timeout" : 30,
+                                "Functions" : {
+                                    "dbupgrade" : {
+                                        "Handler" : "manage_production.dbupgrade_handler",
+                                        "PredefineLogGroup" : true,
+                                        "Extensions" : [ "channel_shareddb" ],
+                                        "Links"  : {
+                                            "database" : {
+                                                "Tier" : "db",
+                                                "Component" : "sharedchannel-db",
+                                                "Version" : ""
+                                            },
+                                            "api" : {
+                                                "Tier" : "api",
+                                                "Component" : "sharedchannel",
+                                                "Instance" : "c1",
+                                                "Version" : "v1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "app" : {
+                    "Components" : {
+                        "app-ecs" : {
+                            "Instances" : {
+                                "default" : {
+                                    "DeploymentUnits" : [ "app-ecs" ]
+                                }
+                            },
+                            "Profiles" :{
+                                "Processor" : "fargate"
+                            },
+                            "Services" : {
+                                "sharedchannel-processor" : {
+                                    "Instances" : {
+                                        "delv" : {
+                                            "Name" : "delivery",
+                                            "Versions" : {
+                                                "c1" : {
+                                                    "DeploymentUnits" : [ "sharedchannel-delivery-c1" ],
+                                                    "Profiles" : {
+                                                        "Deployment" : [  "QueueWorker", "C1Endpoint"]
+                                                    },
+                                                    "ScalingPolicies" : {
+                                                        "numberOfMessages" : {
+                                                            "TrackingResource" : {
+                                                                "Link" : {
+                                                                    "Tier" : "msg",
+                                                                    "Component" : "sharedchannel-sqs",
+                                                                    "Instance" : "outbox",
+                                                                    "Version" : "c1"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "Profiles" : {
+                                                "Deployment" : [  "QueueWorker"]
+                                            },
+                                            "Containers" : {
+                                                "_processor-delv" : {
+                                                    "Extensions" : [ "channel_shareddb" ],
+                                                    "Cpu" : 256,
+                                                    "Memory" : 512,
+                                                    "MaximumMemory" : 512,
+                                                    "Links" : {
+
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "sprd" : {
+                                            "Name" : "spreader",
+                                            "Versions" : {
+                                                "c1" : {
+                                                    "DeploymentUnits" : [ "sharedchannel-spreader-c1" ],
+                                                    "Profiles" : {
+                                                        "Deployment" : [  "QueueWorker", "C1Endpoint"]
+                                                    },
+                                                    "ScalingPolicies" : {
+                                                        "numberOfMessages" : {
+                                                            "TrackingResource" : {
+                                                                "Link" : {
+                                                                    "Tier" : "msg",
+                                                                    "Component" : "sharedchannel-sqs",
+                                                                    "Instance" : "notifications",
+                                                                    "Version" : "c1"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                }
+                                            },
+                                            "Profiles" : {
+                                                "Deployment" : [  "QueueWorker"]
+                                            },
+                                            "Containers" : {
+                                                "_processor-sprd" : {
+                                                    "Extensions" : [ "channel_shareddb" ],
+                                                    "Cpu" : 256,
+                                                    "Memory" : 512,
+                                                    "MaximumMemory" : 512,
+                                                    "Links" : {
+
+                                                    }
+                                                }
+                                            }
+
+                                        },
+                                        "obsv" : {
+                                            "Name" : "observer",
+                                            "Versions" : {
+                                                "c1" : {
+                                                    "DeploymentUnits" : [ "sharedchannel-observer-c1" ],
+                                                    "Profiles" : {
+                                                        "Deployment" : [  "C1Endpoint"]
+                                                    }
+                                                }
+                                            },
+                                            "Profiles" : {
+                                                "Deployment" : [ "SharedChannel"],
+                                                "Processor" : "default"
+                                            },
+                                            "Engine" : "fargate",
+                                            "NetworkMode" : "awsvpc",
+                                            "Containers" : {
+                                                "_processor-obsv" : {
+                                                    "Extensions" : [ "channel_shareddb" ],
+                                                    "Cpu" : 256,
+                                                    "Memory" : 512,
+                                                    "MaximumMemory" : 512
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "msg" : {
+                    "Components" : {
+                        "sharedchannel-s3" : {
+                            "s3" : {
+                                "DeploymentUnits" : [ "sharedchannel-stage"],
+                                "Instances" : {
+                                    "sub" : {
+                                        "Versions" : {
+                                            instance : {}
+                                        }
+                                    },
+                                    "chn" : {
+                                        "Versions" : {
+                                            instance : {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sharedchannel-sqs" : {
+                            "sqs" : {
+                                "Instances" : {
+                                    "notifications" : {
+                                        "Versions" : {
+                                            instance : {
+                                                "DeploymentUnits" : [ "sharedchannel-queues-" + instance ]
+                                            }
+                                        }
+                                    },
+                                    "outbox" : {
+                                        "Versions" : {
+                                           instance : {
+                                                "DeploymentUnits" : [ "sharedchannel-queues-" + instance ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "DeadLetterQueue" : {
+                                    "MaxReceives" : 10
+                                }
+                            }
+                        }
+                    }
+                },
+                "db" : {
+                    "Components" : {
+                        "sharedchannel-db" : {
+                            "db" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : [ "sharedchannel-db"]
+                                    }
+                                },
+                                "Engine" : "aurora-postgresql",
+                                "EngineVersion" : "10",
+                                "Size" : 20,
+                                "GenerateCredentials" : {
+                                    "Enabled" : true,
+                                    "EncryptionScheme" : kmsPrefix
+                                },
+                                "Backup" : {
+                                    "RetentionPeriod" : 14,
+                                    "SnapshotOnDeploy" : true,
+                                    "DeletionPolicy" : "Delete",
+                                    "UpdateReplacePolicy" : "Delete",
+                                    "DeleteAutoBackups" : true
+                                },
+                                "Cluster" : {
+                                    "Parameters" : {
+                                        "ClientSSL" : {
+                                            "Name" : "rds.force_ssl",
+                                            "Value" : 0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "dir" : {
+                    "Components" : {
+                        "auth-userpool" : {
+                            "Title" : "API Authentication using oAuth",
+                            "userpool" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : [ "auth-userpool"]
+                                    }
+                                },
+                                "MFA" : true,
+                                "UnusedAccountTimeout" : 7,
+                                "AdminCreatesUser" : true,
+                                "VerifyEmail" : true,
+                                "VerifyPhone" : true,
+                                "MFAMethods" : [ "SMS" ],
+                                "Username" : {
+                                    "CaseSensitive" : false,
+                                    "Attributes" : [ "email" ],
+                                    "Aliases" : []
+                                },
+                                "Schema" : {
+                                    "email" : {
+                                        "DataType" : "String",
+                                        "Mutable" : true,
+                                        "Required" : true
+                                    },
+                                    "phone_number" : {
+                                        "DataType" : "String",
+                                        "Mutable" : true,
+                                        "Required" : false
+                                    }
+                                },
+                                "HostedUI" : {},
+                                "PasswordPolicy" : {
+                                    "MinimumLength" : 10,
+                                    "Lowercase" : false,
+                                    "Uppercase" : false,
+                                    "Numbers" : false,
+                                    "SpecialCharacters" : false
+                                },
+                                "Security" : {
+                                    "UserDeviceTracking" : true,
+                                    "ActivityTracking" : "enforced"
+                                },
+                                "DefaultClient" : false,
+                                "Resources" : {
+                                    "sharedchannel" + instance : {
+                                        "Server" : {
+                                            "Link" : {
+                                                "Tier" : "api",
+                                                "Component" : "sharedchannel",
+                                                "Instance" : instance,
+                                                "Version" : "v1"
+                                            }
+                                        },
+                                        "Scopes" : {
+                                            "full" : {
+                                                "Name" : "full",
+                                                "Description" : "Full access to the API"
+                                            }
+                                        }
+                                    }
+                                },
+                                "Clients" : {
+                                    "developer" : {
+                                        "Profiles" : {
+                                            "Deployment" : [ "apiClient" ]
+                                        },
+                                        "ResourceScopes" : {
+                                            "sharedchannel" + instance : {
+                                            "Name" : "sharedchannel" + instance,
+                                            "Scopes" : [ "full" ]
+                                            }
+                                        }
+                                    },
+                                    "intergov" : {
+                                        "Instances" : {
+                                            instance : {
+                                                "ResourceScopes" : {
+                                                    "sharedchannel" + instance : {
+                                                        "Name" : "sharedchannel" + instance,
+                                                        "Scopes" : [ "full" ]
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "Profiles" : {
+                                            "Deployment" : [ "apiClient" ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "DeploymentProfiles" : {
+                "Endpoint" + instance : {
+                    "Modes" : {
+                        "*" : {
+                            "*" : {
+                                "Links" : {
+                                    "QUE_IGL_NOTIFICATIONS_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "sharedchannel-sqs",
+                                        "Instance" : "notifications",
+                                        "Version" : instance,
+                                        "Role" : "all"
+                                    },
+                                    "QUE_IGL_DELIVERY_OUTBOX_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "sharedchannel-sqs",
+                                        "Instance" : "outbox",
+                                        "Version" : instance,
+                                        "Role" : "all"
+                                    },
+                                    "BKT_IGL_SUBSCRIPTIONS_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "sharedchannel-s3",
+                                        "Instance" : "sub",
+                                        "Version" : instance,
+                                        "Role" : "all"
+                                    },
+                                    "HUB" : {
+                                        "Tier" : "api",
+                                        "Component" : "sharedchannel",
+                                        "Instance" : instance,
+                                        "Version" : "v1"
+                                    },
+                                    "BKT_IGL_CHANNEL_REPO" : {
+                                        "Tier" : "msg",
+                                        "Component" : "sharedchannel-s3",
+                                        "Instance" : "chn",
+                                        "Version" : instance,
+                                        "Role" : "all"
+                                    },
+                                    "DATABASE" : {
+                                        "Tier" : "db",
+                                        "Component" :"sharedchannel-db",
+                                        "Instance" : "",
+                                        "Version" : ""
+                                    }
+                                },
+                                "SettingNamespaces" : {
+                                    instance : {
+                                        "Name" : "sharedchannel-" + instance,
+                                        "Match" : "partial",
+                                        "IncludeInNamespace" : {
+                                            "Tier" : false,
+                                            "Component" : false,
+                                            "Type" : false,
+                                            "SubComponent" : false,
+                                            "Instance" : false,
+                                            "Version" : false,
+                                            "Name" : true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+[/#macro]

--- a/hamlet/trustbridge/modules/intergov/module.ftl
+++ b/hamlet/trustbridge/modules/intergov/module.ftl
@@ -1,0 +1,1139 @@
+[#ftl]
+
+[@addModule
+    name="intergov"
+    description="The intergov document store API services and their data stores"
+    provider=TRUSTBRIDGE_PROVIDER
+    properties=[
+
+    ]
+
+/]
+
+
+[#macro trustbridge_module_intergov]
+
+    [@loadModule
+
+        blueprint={
+            "Tiers" : {
+                "api" : {
+                    "Components" : {
+                        "api" : {
+                            "Title" : "external facing apis",
+                            "APIGateway" : {
+                                "Instances" : {
+                                    "document" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["document-api"]
+                                            }
+                                        }
+
+                                    },
+                                    "message" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["message-api"]
+                                            }
+                                        }
+
+                                    },
+                                    "messagerx" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["messagerx-api"]
+                                            }
+                                        }
+
+                                    },
+                                    "subscriptions" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["subscriptions-api"]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Certificate" : {
+                                    "IncludeInDomain" : {
+                                        "Environment" : true
+                                    },
+                                    "IncludeInHost" : {
+                                        "Product" : false,
+                                        "Environment" : false,
+                                        "Tier" : false,
+                                        "Component" : false,
+                                        "Instance" : true,
+                                        "Version" : false,
+                                        "Host" : false
+                                    }
+                                },
+                                "EndpointType" : "REGIONAL",
+                                "Mapping" : {
+                                    "IncludeStage" : true
+                                },
+                                "WAF" : {
+                                    "IPAddressGroups" : ["_global"],
+                                    "OWASP" : false
+                                },
+                                "AccessLogging" : {
+                                    "aws:KinesisFirehose" : true
+                                },
+                                "Links" : {
+                                    "lambda" : {
+                                        "Tier" : "api",
+                                        "Component" : "api-lambda",
+                                        "Function" : "api"
+                                    },
+                                    "auth" : {
+                                        "Tier" : "dir",
+                                        "Component" : "auth-userpool",
+                                        "Instance" : "",
+                                        "Version" : ""
+                                    }
+                                }
+                            }
+                        },
+                        "api-lambda" : {
+                            "Lambda" : {
+                                "Instances" : {
+                                    "document" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["document-api-imp"]
+                                            }
+                                        },
+                                        "Links"  : {
+                                            "BKT_IGL_DOCAPI_OBJ_LAKE" : {
+                                                "Tier" : "db",
+                                                "Component" : "repo-s3",
+                                                "Instance" : "objlake",
+                                                "Version" : "",
+                                                "Role" : "all"
+                                            },
+                                            "BKT_IGL_DOCAPI_OBJ_ACL" : {
+                                                "Tier" : "db",
+                                                "Component" : "repo-s3",
+                                                "Instance" : "objacl",
+                                                "Version" : "",
+                                                "Role" : "all"
+                                            },
+                                            "api" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Direction" : "inbound",
+                                                "Version" : "v1"
+                                            }
+                                        }
+                                    },
+                                    "message" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["message-api-imp"]
+                                            }
+                                        },
+                                        "Links"  : {
+                                            "BKT_IGL_MSGAPI_MESSAGE_LAKE" : {
+                                                "Tier" : "db",
+                                                "Component" : "repo-s3",
+                                                "Instance" : "msglake",
+                                                "Version" : "",
+                                                "Role" : "all"
+                                            },
+                                            "QUE_IGL_MSG_RX_API_BC_INBOX" : {
+                                                "Tier" : "msg",
+                                                "Component" : "repo-sqs",
+                                                "Instance" : "bcin",
+                                                "Version" : "",
+                                                "Role" : "produce"
+                                            },
+                                            "QUE_IGL_MSG_RX_API_OUTBOX_REPO" : {
+                                                "Tier" : "msg",
+                                                "Component" : "repo-sqs",
+                                                "Instance" : "pubout",
+                                                "Version" : "",
+                                                "Role" : "produce"
+                                            },
+                                            "api" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Direction" : "inbound",
+                                                "Version" : "v1"
+                                            }
+                                        }
+                                    },
+                                    "messagerx" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["messagerx-api-imp"]
+                                            }
+                                        },
+                                        "Profiles" : {
+                                            "Deployment" : [ "Processor" ]
+                                        },
+                                        "Links"  : {
+                                            "QUE_IGL_MSG_RX_API_BC_INBOX" : {
+                                                "Tier" : "msg",
+                                                "Component" : "repo-sqs",
+                                                "Instance" : "bcin",
+                                                "Version" : "",
+                                                "Role" : "produce"
+                                            },
+                                            "QUE_IGL_CHANNEL_NOTIFICATION_REPO" : {
+                                                "Tier" : "msg",
+                                                "Component" : "repo-sqs",
+                                                "Instance" : "chnnot",
+                                                "Version" : "",
+                                                "Role" : "all"
+                                            },
+                                            "api" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Direction" : "inbound",
+                                                "Version" : "v1"
+                                            }
+                                        }
+                                    },
+                                    "subscriptions" : {
+                                        "Versions" : {
+                                            "v1" : {
+                                                "DeploymentUnits" : ["subscriptions-api-imp"]
+                                            }
+                                        },
+                                        "Links" : {
+                                            "BKT_IGL_SUBSCR_API_REPO" : {
+                                                "Tier" : "db",
+                                                "Component" : "repo-s3",
+                                                "Instance" : "sub",
+                                                "Version" : "",
+                                                "Role" : "all"
+                                            },
+                                            "api" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Direction" : "inbound",
+                                                "Version" : "v1"
+                                            }
+                                        }
+                                    }
+                                },
+                                "RunTime" : "python3.6",
+                                "MemorySize" : 256,
+                                "Timeout" : 30,
+                                "Functions" : {
+                                    "api" : {
+                                        "Handler" : "wsgi_handler.handler",
+                                        "PredefineLogGroup" : true,
+                                        "Fragment" : "_intergov_srv",
+                                        "Environment" : {
+                                            "Json" : {
+                                                "Prefix" : ""
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "app" : {
+                    "Components" : {
+                        "app-ecs" : {
+                            "ECS" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["app-ecs"]
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Processor" : "fargate"
+                                },
+                                "Services" : {
+                                    "processor" : {
+                                        "Instances" : {
+                                            "msg" : {
+                                                "Name" : "message",
+                                                "DeploymentUnits" : ["proc-msg"],
+                                                "Profiles" : {
+                                                    "Deployment" : [ "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "bcin",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-msg" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_PROC_BC_INBOX" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "bcin",
+                                                                "Version" : "",
+                                                                "Role" : "consume"
+                                                            },
+                                                            "QUE_IGL_PROC_OBJ_RETR_REPO" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "objret",
+                                                                "Version" : "",
+                                                                "Role" : "produce"
+                                                            },
+                                                            "QUE_IGL_PROC_OBJ_OUTBOX_REPO" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "pubout",
+                                                                "Version" : "",
+                                                                "Role" : "produce"
+                                                            },
+                                                            "BKT_IGL_PROC_MESSAGE_LAKE" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-s3",
+                                                                "Instance" : "msglake",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            },
+                                                            "BKT_IGL_PROC_OBJECT_ACL_REPO" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-s3",
+                                                                "Instance" : "objacl",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            },
+                                                            "DB_IGL_PROC_BCH_OUTBOX_REPO" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-rds",
+                                                                "Instance" : "apiout",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                }
+
+                                            },
+                                            "callbdel" : {
+                                                "Name" : "callbackdeliver",
+                                                "DeploymentUnits" : ["proc-callbdel"],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "dlvout",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-callbdel" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_PROC_DELIVERY_OUTBOX_REPO" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "dlvout",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "callbspd" : {
+                                                "Name" : "callbackspread",
+                                                "DeploymentUnits" : [ "proc-callbspd"],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "pubout",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-callbspd" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_PROC_OBJ_OUTBOX_REPO" :{
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "pubout",
+                                                                "Version" : "",
+                                                                "Role" : "consume"
+                                                            },
+                                                            "QUE_IGL_PROC_DELIVERY_OUTBOX_REPO" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "dlvout",
+                                                                "Version" : "",
+                                                                "Role" : "produce"
+                                                            },
+                                                            "BKT_IGL_PROC_SUB_REPO" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-s3",
+                                                                "Instance" : "sub",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "rejstat" : {
+                                                "Name" : "rejectedstatus",
+                                                "DeploymentUnits" : ["proc-rejstat"],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "rejmsg",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-rejstat" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_PROC_REJECTED_MESSAGES_REPO" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "rejmsg",
+                                                                "Version" : "",
+                                                                "Role" : "consume"
+                                                            },
+                                                            "BKT_IGL_PROC_MESSAGE_LAKE_REPO" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-s3",
+                                                                "Instance" : "msglake",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+
+                                            },
+                                            "channelrouter" : {
+                                                "Name" : "channelrouter",
+                                                "DeploymentUnits" : [ "proc-channelrouter" ],
+                                                "Profiles" : {
+                                                    "Deployment" : [ "Processor" ]
+                                                },
+                                                "Containers" : {
+                                                    "_processor-channelrouter" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "DB_IGL_PROC_BCH_OUTBOX" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-rds",
+                                                                "Instance" : "apiout",
+                                                                "Version" : ""
+                                                            },
+                                                            "QUE_IGL_PROC_BCH_CHANNEL_PENDING_MESSAGE" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "chnpendmsg",
+                                                                "Version" : "",
+                                                                "Role" : "produce"
+                                                            },
+                                                            "QUE_IGL_BCH_MESSAGE_UPDATES" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "msgups",
+                                                                "Version" : "",
+                                                                "Role" : "produce"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "docspider" : {
+                                                "Name" : "docspider",
+                                                "DeploymentUnits" : [ "proc-docspider" ],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "objret",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-docspider" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "BKT_IGL_PROC_OBJ_SPIDER_OBJ_LAKE" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-s3",
+                                                                "Instance" : "objlake",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            },
+                                                            "QUE_IGL_PROC_OBJ_SPIDER_OBJ_RETRIEVAL" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "objret",
+                                                                "Version" : "",
+                                                                "Role" : "consume"
+                                                            },
+                                                            "BKT_IGL_PROC_OBJ_SPIDER_OBJ_ACL" : {
+                                                                "Tier" : "db",
+                                                                "Component" : "repo-s3",
+                                                                "Instance" : "objacl",
+                                                                "Version" : "",
+                                                                "Role" : "all"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "channelpoller" : {
+                                                "Name" : "channelpoller",
+                                                "DeploymentUnits" : [ "proc-channelpoller" ],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "chnpendmsg",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-channelpoller" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_PROC_BCH_CHANNEL_PENDING_MESSAGE" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "chnpendmsg",
+                                                                "Role" : "consume"
+                                                            },
+                                                            "QUE_IGL_BCH_MESSAGE_UPDATES" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "msgups",
+                                                                "Role" : "produce"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "msgupdater" : {
+                                                "Name" : "msgupdater",
+                                                "DeploymentUnits" : [ "proc-msgupdater" ],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor", "QueueWorker"]
+                                                },
+                                                "ScalingPolicies" : {
+                                                    "numberOfMessages" : {
+                                                        "TrackingResource" : {
+                                                            "Link" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "msgups",
+                                                                "Version" : ""
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Containers" : {
+                                                    "_processor-msgupdater" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_BCH_MESSAGE_UPDATES" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "msgups",
+                                                                "Role" : "all"
+                                                            },
+                                                            "IGL_PROC_BCH_MESSAGE_API" : {
+                                                                "Tier" : "api",
+                                                                "Component" : "api",
+                                                                "Instance" : "message",
+                                                                "Version" : "v1"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "subhandler" : {
+                                                "Name" : "subhandler",
+                                                "DeploymentUnits" : [ "proc-subhandler" ],
+                                                "Profiles" : {
+                                                    "Deployment" : [  "Processor" ]
+                                                },
+                                                "Containers" : {
+                                                    "_processor-subhandler" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "IGL_PROC_BCH_MESSAGE_RX_API" : {
+                                                                "Tier" : "api",
+                                                                "Component" : "api",
+                                                                "Instance" : "messagerx",
+                                                                "Version" : "v1"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "chnmsgret" : {
+                                                "Name" : "chnmsgretriever",
+                                                "DeploymentUnits" : [ "proc-chnmsgret" ],
+                                                "Profiles" : {
+                                                    "Deployment" : [ "Processor" ]
+                                                },
+                                                "Containers" : {
+                                                    "_processor-chnmsgret" : {
+                                                        "Extensions" : [ "_intergov_srv" ]
+                                                        "Cpu" : 256,
+                                                        "Memory" : 512,
+                                                        "MaximumMemory" : 512,
+                                                        "Links" : {
+                                                            "QUE_IGL_CHANNEL_NOTIFICATION_REPO" : {
+                                                                "Tier" : "msg",
+                                                                "Component" : "repo-sqs",
+                                                                "Instance" : "chnnot",
+                                                                "Role" : "all"
+                                                            },
+                                                            "QUE_IGL_PROC_BC_INBOX": {
+                                                                "Tier": "msg",
+                                                                "Component": "repo-sqs",
+                                                                "Instance": "bcin",
+                                                                "Version": "",
+                                                                "Role": "produce"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "msg" : {
+                    "Components" : {
+                        "repo-sqs" : {
+                            "SQS" : {
+                                "Instances" : {
+                                    "apiin" :{
+                                        "Name" : "apiinbox",
+                                        "DeploymentUnits" : [ "repo-sqs-a"]
+                                    },
+                                    "bcin" : {
+                                        "Name" : "bcinbox",
+                                        "DeploymentUnits" : [ "repo-sqs-a"]
+                                    },
+                                    "dlvout" : {
+                                        "Name" : "deliveryoutbox",
+                                        "DeploymentUnits" : [ "repo-sqs-a"]
+                                    },
+                                    "objret" : {
+                                        "Name" : "objectretrieval",
+                                        "DeploymentUnits" : [ "repo-sqs-b"]
+                                    },
+                                    "pubout" : {
+                                        "Name" : "publishoutbox",
+                                        "DeploymentUnits" : [ "repo-sqs-b"]
+                                    },
+                                    "rejmsg" : {
+                                        "Name" : "rejectedmessage",
+                                        "DeploymentUnits" : [ "repo-sqs-b"]
+                                    },
+                                    "chnpendmsg" : {
+                                        "Name" : "channelpendingmessage",
+                                        "DeploymentUnits" : [ "repo-sqs-c"]
+                                    },
+                                    "msgups" : {
+                                        "Name" : "messageupdates",
+                                        "DeploymentUnits" : [ "repo-sqs-c" ]
+                                    },
+                                    "chnnot" : {
+                                        "Name" : "channelnotifications",
+                                        "DeploymentUnits" : [ "repo-sqs-c"]
+                                    }
+                                },
+                                "MessageRetentionPeriod" : 345600,
+                                "VisibilityTimeout" : 90,
+                                "DeadLetterQueue" : {
+                                    "MaxReceives" : 20
+                                },
+                                "Alerts": {
+                                    "delays": {
+                                        "Resource": {
+                                            "Id": "queue"
+                                        },
+                                        "Name": "ProcessingDelays",
+                                        "Severity": "warn",
+                                        "Description": "Messages are being retried",
+                                        "Metric": "ApproximateAgeOfOldestMessage",
+                                        "Threshold": 900,
+                                        "Statistic": "Maximum",
+                                        "Time": 300
+                                    },
+                                    "failures": {
+                                        "Resource": {
+                                            "Id": "dlq"
+                                        },
+                                        "Name": "ProcessingFailures",
+                                        "Severity": "error",
+                                        "Description": "Messages are being rejected",
+                                        "Metric": "ApproximateNumberOfMessagesVisible",
+                                        "Threshold": 1,
+                                        "Statistic": "Minimum",
+                                        "Time": 300
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "db" : {
+                    "Components" : {
+                        "repo-s3" : {
+                            "S3" : {
+                                "Instances" : {
+                                    "msglake" : {
+                                        "Name" : "messagelake",
+                                        "DeploymentUnits" : [ "repo-s3-a"]
+                                    },
+                                    "objacl" : {
+                                        "Name" : "objectacl",
+                                        "DeploymentUnits" : [ "repo-s3-a"]
+                                    },
+                                    "objlake" : {
+                                        "Name" : "objectlake",
+                                        "DeploymentUnits" : [ "repo-s3-a"]
+                                    },
+                                    "sub" : {
+                                        "Name" : "subscriptions",
+                                        "DeploymentUnits" : [ "repo-s3-b"]
+                                    }
+                                }
+                            }
+                        },
+                        "repo-rds" : {
+                            "RDS" : {
+                                "Instances" : {
+                                    "apiout" : {
+                                        "Name" : "apioutbox",
+                                        "DeploymentUnits" : [ "repo-rds-apiout"]
+                                    }
+                                },
+                                "Engine" : "aurora-postgresql",
+                                "EngineVersion" : "10",
+                                "GenerateCredentials" : {
+                                    "Enabled" : true,
+                                    "EncryptionScheme" : "kms+base64"
+                                },
+                                "Backup" : {
+                                    "RetentionPeriod" : 14,
+                                    "SnapshotOnDeploy" : true,
+                                    "DeletionPolicy" : "Delete",
+                                    "UpdateReplacePolicy" : "Delete",
+                                    "DeleteAutoBackups" : true
+                                },
+                                "Cluster" : {
+                                    "Parameters" : {
+                                        "ClientSSL" : {
+                                            "Name" : "rds.force_ssl",
+                                            "Value" : 0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "dir" : {
+                    "Components" : {
+                        "auth-userpool" : {
+                            "userpool" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : [ "auth-userpool"]
+                                    }
+                                },
+                                "MFA" : true,
+                                "UnusedAccountTimeout" : 7,
+                                "AdminCreatesUser" : true,
+                                "VerifyEmail" : true,
+                                "VerifyPhone" : true,
+                                "MFAMethods" : [ "SMS", "SoftwareToken" ],
+                                "Username" : {
+                                    "CaseSensitive" : false,
+                                    "Attributes" : [ "email" ],
+                                    "Aliases" : []
+                                },
+                                "Schema" : {
+                                    "email" : {
+                                        "DataType" : "String",
+                                        "Mutable" : true,
+                                        "Required" : true
+                                    },
+                                    "phone_number" : {
+                                        "DataType" : "String",
+                                        "Mutable" : true,
+                                        "Required" : false
+                                    }
+                                },
+                                "HostedUI" : {},
+                                "PasswordPolicy" : {
+                                    "MinimumLength" : 10,
+                                    "Lowercase" : false,
+                                    "Uppercase" : false,
+                                    "Numbers" : false,
+                                    "SpecialCharacters" : false
+                                },
+                                "Security" : {
+                                    "UserDeviceTracking" : true,
+                                    "ActivityTracking" : "enforced"
+                                },
+                                "DefaultClient" : false,
+                                "AuthProviders" : {
+                                    "GlobalAuth" : {
+                                        "Profiles" : {
+                                            "Deployment" : [ "federatedAuth" ]
+                                        }
+                                    }
+                                },
+                                "Resources" : {
+                                    "document" : {
+                                        "Server" : {
+                                            "Link" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Instance" : "document",
+                                                "Version" : "v1"
+                                            }
+                                        },
+                                        "Scopes" : {
+                                            "full" : {
+                                                "Name" : "full",
+                                                "Description" : "Full access to the API"
+                                            }
+                                        }
+                                    },
+                                    "message" : {
+                                        "Server" : {
+                                            "Link" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Instance" : "message",
+                                                "Version" : "v1"
+                                            }
+                                        },
+                                        "Scopes" : {
+                                            "full" : {
+                                                "Name" : "full",
+                                                "Description" : "Full access to the API"
+                                            }
+                                        }
+                                    },
+                                    "messagerx" : {
+                                        "Server" : {
+                                            "Link" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Instance" : "messagerx",
+                                                "Version" : "v1"
+                                            }
+                                        },
+                                        "Scopes" : {
+                                            "full" : {
+                                                "Name" : "full",
+                                                "Description" : "Full access to the API"
+                                            }
+                                        }
+                                    },
+                                    "subscriptions" : {
+                                        "Server" : {
+                                            "Link" : {
+                                                "Tier" : "api",
+                                                "Component" : "api",
+                                                "Instance" : "subscriptions",
+                                                "Version" : "v1"
+                                            }
+                                        },
+                                        "Scopes" : {
+                                            "full" : {
+                                                "Name" : "full",
+                                                "Description" : "Full access to the API"
+                                            }
+                                        }
+                                    }
+                                },
+                                "Clients" : {
+                                    "developer" : {
+                                        "Profiles" : {
+                                            "Deployment" : [ "apiClient" ]
+                                        },
+                                        "ResourceScopes" : {
+                                            "document" : {
+                                            "Name" : "document",
+                                            "Scopes" : [ "full" ]
+                                            },
+                                            "message" : {
+                                            "Name" : "message",
+                                            "Scopes" : [ "full" ]
+                                            },
+                                            "messagerx" : {
+                                            "Name" : "messagerx",
+                                            "Scopes" : [ "full" ]
+                                            },
+                                            "subscriptions" : {
+                                            "Name" : "subscriptions",
+                                            "Scopes" : [ "full" ]
+                                            }
+                                        }
+                                    },
+                                    "trade" : {
+                                        "Profiles" : {
+                                            "Deployment" : [ "apiClient" ]
+                                        },
+                                        "ResourceScopes" : {
+                                            "document" : {
+                                            "Name" : "document",
+                                            "Scopes" : [ "full" ]
+                                            },
+                                            "message" : {
+                                            "Name" : "message",
+                                            "Scopes" : [ "full" ]
+                                            },
+                                            "messagerx" : {
+                                            "Name" : "messagerx",
+                                            "Scopes" : [ "full" ]
+                                            },
+                                            "subscriptions" : {
+                                            "Name" : "subscriptions",
+                                            "Scopes" : [ "full" ]
+                                            }
+                                        }
+                                    },
+                                    "docspider" : {
+                                        "Instances" : {
+                                            "c1" : {},
+                                            "c2" : {}
+                                        },
+                                        "Profiles" : {
+                                            "Deployment" : [ "apiClient" ]
+                                        },
+                                        "ResourceScopes" : {
+                                            "document" : {
+                                            "Name" : "document",
+                                            "Scopes" : [ "full" ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "DeploymentProfiles" : {
+                "QueueWorker" : {
+                    "Modes" : {
+                        "*" : {
+                            "service" : {
+                                "Profiles" : {
+                                    "Processor" : "QueueWorker"
+                                },
+                                "ScalingPolicies" : {
+                                    "numberOfMessages" : {
+                                        "Type" : "Stepped",
+                                        "TrackingResource" : {
+                                            "Link" : {
+                                                "Tier" : "msg",
+                                                "Component" : "_REPLACEWITHLINK_",
+                                                "Instance" : "_REPLACEWITHLINK_",
+                                                "Version" : "_REPLACEWITHLINK_"
+                                            },
+                                            "MetricTrigger" : {
+                                                "Namespace": "AWS/SQS",
+                                                "Name" : "NumberOfMessages",
+                                                "Metric" : "ApproximateNumberOfMessagesVisible",
+                                                "Threshold" : 0,
+                                                "Severity" : "info",
+                                                "Statistic" : "Sum",
+                                                "Operator" : "GreaterThanThreshold",
+                                                "Periods" : 1,
+                                                "Time" : 60,
+                                                "Resource" : {
+                                                    "Id" : "queue"
+                                                }
+                                            }
+                                        },
+                                        "Stepped" : {
+                                            "CapacityAdjustment" : "Exact",
+                                            "Adjustments": {
+                                                "out1" : {
+                                                    "LowerBound": 1,
+                                                    "UpperBound": 1000,
+                                                    "AdjustmentValue": 1
+                                                },
+                                                "out2" : {
+                                                    "LowerBound": 1000,
+                                                    "AdjustmentValue": 2
+                                                },
+                                                "in1" : {
+                                                    "UpperBound": 1,
+                                                    "AdjustmentValue": 0
+                                                }
+                                            }
+                                        },
+                                        "Cooldown" : {
+                                            "ScaleOut" : 10,
+                                            "ScaleIn" : 300
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "Processor" : {
+                    "Modes" : {
+                        "*" : {
+                            "*" : {
+                                "SettingNamespaces" : {
+                                    "processor" : {
+                                        "Name" : "intergov-processor",
+                                        "Match" : "partial",
+                                        "IncludeInNamespace" : {
+                                            "Tier" : false,
+                                            "Component" : false,
+                                            "Type" : false,
+                                            "SubComponent" : false,
+                                            "Instance" : false,
+                                            "Version" : false,
+                                            "Name" : true
+                                        }
+                                    }
+                                }
+                            },
+                            "service" : {
+                                "Engine" : "fargate",
+                                "NetworkMode" : "awsvpc",
+                                "Profiles" : {
+                                    "Deployment" : [ "Processor" ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "apiClient" : {
+                    "Modes" : {
+                    "*" : {
+                        "userpoolclient" : {
+                        "OAuth" : {
+                            "Scopes" : [],
+                            "Flows" : [ "client_credentials"]
+                        },
+                        "ClientGenerateSecret" : true,
+                        "AuthProviders" : [ ]
+                        }
+                    }
+                    }
+                },
+                "apiFullAccess" : {
+                    "Modes" : {
+                        "*" : {
+                            "userpoolclient" : {
+                                "ResourceScopes" : {
+                                    "document" : {
+                                    "Name" : "document",
+                                    "Scopes" : [ "full" ]
+                                    },
+                                    "message" : {
+                                    "Name" : "message",
+                                    "Scopes" : [ "full" ]
+                                    },
+                                    "messagerx" : {
+                                    "Name" : "messagerx",
+                                    "Scopes" : [ "full" ]
+                                    },
+                                    "subscriptions" : {
+                                    "Name" : "subscriptions",
+                                    "Scopes" : [ "full" ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/hamlet/trustbridge/provider.ftl
+++ b/hamlet/trustbridge/provider.ftl
@@ -1,0 +1,3 @@
+[#ftl]
+
+[#assign TRUSTBRIDGE_PROVIDER = "trustbridge" ]


### PR DESCRIPTION
Adds a hamlet based plugin which allows users to implement different sections of the trustbridge deployment in their own hamlet solutions. This would allow for our deployment process and architecture to be shared with others. 